### PR TITLE
Add interchangeable engine support (Claude + OpenAI Codex) and adapt CLI, runner, logs, and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dangeresque
 
-Run Claude Code AFK in isolated git worktrees with automatic review and human merge control.
+Run Claude Code or OpenAI Codex AFK in isolated git worktrees with automatic review and human merge control.
 
 ## The Problem
 
@@ -37,7 +37,9 @@ No code touches your main branch until you explicitly merge.
 ## Requirements
 
 - Node.js >= 22
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
+- At least one engine CLI installed and authenticated:
+  - **Claude Code**: install/auth per Anthropic docs
+  - **OpenAI Codex CLI**: `npm install -g @openai/codex` and configure `OPENAI_API_KEY`
 - [GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated
 - git
 - jq (for notification hooks)
@@ -245,9 +247,45 @@ Options:
   --effort <level>    Override effort (default: max) [low, medium, high, max]
 ```
 
+### Switching Engines
+
+Dangeresque now supports two interchangeable execution engines:
+
+- `claude` (default): Uses `claude` CLI with `--worktree` and native Claude session tracking.
+- `codex`: Uses `codex exec --json --full-auto` and runs inside the same isolated worktree model.
+
+Set the engine in `.dangeresque/config.json` (recommended):
+
+```bash
+{
+  "engine": "codex",
+  "model": "gpt-5.4"
+}
+```
+
+Or use an environment override for a single run:
+
+```bash
+DANGERESQUE_ENGINE=codex dangeresque run --issue 63
+```
+
+Help output adapts to the active engine (`config.engine` or `DANGERESQUE_ENGINE`): Claude help shows `--effort`, while Codex help omits it because `--effort` is Claude-only and ignored in Codex mode.
+
+### Codex option mapping
+
+- `model` maps directly to `codex exec --model <model>`.
+- `effort` has no direct Codex CLI flag; dangeresque passes it as an explicit prompt hint for planning depth.
+- Codex runs use `--full-auto` (safe automation mode) and **do not** use dangerous bypass flags.
+
+### Dynamic help output
+
+- Help text adapts to the active engine (`config.engine` or `DANGERESQUE_ENGINE`).
+- Claude help emphasizes `--effort`.
+- Codex help de-emphasizes effort and shows Codex-native execution notes.
+
 ### `dangeresque logs`
 
-Pretty-print Claude Code session transcripts.
+Pretty-print engine transcripts (Claude or Codex JSONL).
 
 ```
 Options:
@@ -336,8 +374,9 @@ This keeps the prompt focused. Use `dangeresque stage` to add guidance the worke
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `model` | string | `"claude-opus-4-6"` | Claude model ID |
-| `permissionMode` | string | `"acceptEdits"` | Claude Code permission mode |
+| `engine` | string | `"claude"` | Execution engine (`claude` or `codex`) |
+| `model` | string | `"claude-opus-4-6"` | Model ID passed to the selected engine |
+| `permissionMode` | string | `"acceptEdits"` | Sandbox/permission mode for the selected engine |
 | `effort` | string | `"max"` | Effort level: low, medium, high, max |
 | `headless` | boolean | `true` | Run with `-p` flag (set false for interactive) |
 | `allowedTools` | string[] | _(see below)_ | Tools auto-approved without prompting |
@@ -370,6 +409,12 @@ Beyond policy, host-native gives you:
 - **Granular permissions** — `acceptEdits` mode with explicit `allowedTools`/`disallowedTools` instead of `--dangerously-skip-permissions`
 
 The safety model is different:
+
+## MCP setup (Claude vs Codex)
+
+- **Claude Code** MCP uses your existing Claude setup.
+- **Codex** MCP is configured in `~/.codex/config.toml` under `[mcp_servers]`.
+- Keep entries aligned across both tools if you want equivalent MCP behavior for both engines.
 
 | Layer | Docker-based | Dangeresque |
 |-------|-------------|-------------|

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dangeresque",
   "version": "0.1.0",
-  "description": "Orchestrate bounded AFK Claude Code runs in git worktrees with human review",
+  "description": "Orchestrate bounded AFK Claude Code or OpenAI Codex runs in git worktrees with human review",
   "type": "module",
   "packageManager": "yarn@4.9.2",
   "bin": "./dist/cli.js",
@@ -16,6 +16,7 @@
   },
   "keywords": [
     "claude",
+    "codex",
     "ai",
     "agent",
     "worktree",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import {
   loadConfig,
   validateSetup,
   resolveProjectRoot,
+  type Engine,
 } from "./config.js";
 import { runWorker, runReview, fetchIssue, postRunComment } from "./runner.js";
 import { listWorktrees, mergeWorktree, discardWorktree, getWorktreeResults, getArchivedResults, resolveBranch, cleanArchivedRuns, readPidFile } from "./worktree.js";
@@ -11,8 +12,17 @@ import { initProject } from "./init.js";
 import { stageComment } from "./stage.js";
 import { resolveSessionPath, tailLog } from "./logs.js";
 
-const USAGE = `
-dangeresque — bounded AFK Claude Code runs with human review
+function usageForEngine(engine: Engine): string {
+  const engineLine = engine === "codex"
+    ? "Engine: codex • codex exec --full-auto --json\nModel: gpt-5.4 (override with --model)"
+    : "Engine: claude (default) • headless -p mode";
+  const engineRunNotes = engine === "codex"
+    ? ""
+    : "  --effort <level>  Override effort level (default: max) [low, medium, high, max]\n";
+
+  return `
+dangeresque — bounded AFK Claude Code or Codex runs with human review
+${engineLine}
 
 Commands:
   run [options]                        Execute worker + review pass
@@ -33,8 +43,8 @@ Run options:
   --name <name>     Custom worktree name (default: dangeresque-<timestamp>)
   --no-review       Skip the review pass
   --interactive     Run interactively (default: headless with -p)
-  --model <model>   Override model (default: claude-opus-4-6)
-  --effort <level>  Override effort level (default: max) [low, medium, high, max]
+  --model <model>   Override model (default: ${engine === "codex" ? "gpt-5.4" : "claude-opus-4-6"})
+${engineRunNotes}  Advanced: --engine <name> (hidden), DANGERESQUE_ENGINE env var
   --help            Show this help
 
 Examples:
@@ -44,12 +54,25 @@ Examples:
   dangeresque stage 63 --comment "root cause confirmed" --mode IMPLEMENT
   dangeresque init
 `;
+}
+
+function currentHelpEngine(): Engine {
+  const envEngine = process.env.DANGERESQUE_ENGINE?.toLowerCase();
+  if (envEngine === "claude" || envEngine === "codex") return envEngine;
+
+  try {
+    const config = loadConfig(resolveProjectRoot());
+    return config.engine;
+  } catch {
+    return "claude";
+  }
+}
 
 async function main() {
   const args = process.argv.slice(2);
 
   if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
-    console.log(USAGE);
+    console.log(usageForEngine(currentHelpEngine()));
     process.exit(0);
   }
 
@@ -85,7 +108,7 @@ async function main() {
       break;
     default:
       console.error(`Unknown command: ${command}`);
-      console.log(USAGE);
+      console.log(usageForEngine(currentHelpEngine()));
       process.exit(1);
   }
 }
@@ -103,12 +126,17 @@ async function cmdRun(args: string[]) {
   }
 
   const config = loadConfig(projectRoot);
+  const envEngine = process.env.DANGERESQUE_ENGINE?.toLowerCase();
+  if (envEngine === "claude" || envEngine === "codex") {
+    config.engine = envEngine;
+  }
 
   // Parse CLI overrides
   let name: string | undefined;
   let review = true;
   let issueNumber: number | undefined;
   let mode: string | undefined;
+  let effortFlagUsed = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--name" && args[i + 1]) {
@@ -119,7 +147,16 @@ async function cmdRun(args: string[]) {
       config.headless = false;
     } else if (args[i] === "--model" && args[i + 1]) {
       config.model = args[++i];
+    // Hidden advanced override flag (kept for power users)
+    } else if (args[i] === "--engine" && args[i + 1]) {
+      const engine = args[++i].toLowerCase();
+      if (engine !== "claude" && engine !== "codex") {
+        console.error("--engine must be one of: claude, codex");
+        process.exit(1);
+      }
+      config.engine = engine;
     } else if (args[i] === "--effort" && args[i + 1]) {
+      effortFlagUsed = true;
       config.effort = args[++i];
     } else if (args[i] === "--issue" && args[i + 1]) {
       issueNumber = parseInt(args[++i], 10);
@@ -149,6 +186,10 @@ async function cmdRun(args: string[]) {
 
   const effectiveMode = mode ?? "INVESTIGATE";
 
+  if (config.engine === "codex" && effortFlagUsed) {
+    console.warn("⚠️  --effort is ignored in codex mode");
+  }
+
   // Auto-generate name from mode + issue when not explicitly provided
   if (!name && issueNumber) {
     name = `${effectiveMode.toLowerCase()}-${issueNumber}`;
@@ -160,6 +201,7 @@ async function cmdRun(args: string[]) {
     console.log(`  Issue: #${issueData.number} — ${issueData.title}`);
     console.log(`  Mode: ${effectiveMode}`);
   }
+  console.log(`  Engine: ${config.engine}`);
   console.log(`  Model: ${config.model} (effort: ${config.effort})`);
   console.log(`  Mode: ${config.headless ? "headless (-p)" : "interactive"}`);
   console.log(`  Review pass: ${review ? "yes" : "no"}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,19 +9,23 @@ export const RESULT_FILE = "RUN_RESULT.md";
 export const PID_FILE = ".dangeresque.pid";
 export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
 
+export type Engine = "claude" | "codex";
+
 /** Convert absolute path to claude project hash (e.g. /Users/foo/.bar → -Users-foo--bar) */
 export function projectHash(cwd: string): string {
   return cwd.replace(/[/.]/g, "-");
 }
 
 export interface DangeresqueConfig {
-  /** Model to use (default: claude-opus-4-6) */
+  /** Execution engine (default: claude) */
+  engine: Engine;
+  /** Model to use */
   model: string;
-  /** Permission mode (default: acceptEdits) */
+  /** Permission mode (engine-specific) */
   permissionMode: string;
-  /** Effort level (default: max) */
+  /** Effort level (engine-specific) */
   effort: string;
-  /** Run headless with -p flag (default: true). Set false for interactive mode. */
+  /** Run headless (default: true). Set false for interactive mode where supported. */
   headless: boolean;
   /** Allowed tools patterns */
   allowedTools: string[];
@@ -36,6 +40,7 @@ export interface DangeresqueConfig {
 }
 
 const DEFAULT_CONFIG: DangeresqueConfig = {
+  engine: "claude",
   model: "claude-opus-4-6",
   permissionMode: "acceptEdits",
   effort: "max",
@@ -91,6 +96,10 @@ export function validateSetup(projectRoot: string): ValidationResult {
   }
 
   const config = loadConfig(projectRoot);
+
+  if (!["claude", "codex"].includes(config.engine)) {
+    errors.push(`Invalid engine '${config.engine}' (expected 'claude' or 'codex')`);
+  }
 
   const workerPromptPath = join(configDir, config.workerPrompt);
   if (!existsSync(workerPromptPath)) {

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -4,8 +4,6 @@ import { createInterface } from "node:readline";
 import { CLAUDE_PROJECTS_DIR, projectHash } from "./config.js";
 import type { PidInfo } from "./worktree.js";
 
-// --- ANSI colors (respects NO_COLOR) ---
-
 const useColor = !process.env.NO_COLOR;
 const c = {
   cyan: (s: string) => useColor ? `\x1b[36m${s}\x1b[0m` : s,
@@ -22,13 +20,13 @@ function truncate(s: string, max = 200): string {
   return oneLine.length > max ? oneLine.slice(0, max) + "..." : oneLine;
 }
 
-// --- Session path resolution ---
-
 export function resolveSessionPath(pidInfo: PidInfo, phase: "worker" | "review", worktreePath?: string): string | null {
+  const trackedLogPath = phase === "review" ? pidInfo.reviewLogPath : pidInfo.workerLogPath;
+  if (trackedLogPath && existsSync(trackedLogPath)) return trackedLogPath;
+
   const sessionId = phase === "review" ? pidInfo.reviewSessionId : pidInfo.workerSessionId;
   if (!sessionId) return null;
 
-  // Try stored hash first, then fall back to worktree path hash
   if (pidInfo.projectHash) {
     const p = join(CLAUDE_PROJECTS_DIR, pidInfo.projectHash, `${sessionId}.jsonl`);
     if (existsSync(p)) return p;
@@ -40,15 +38,9 @@ export function resolveSessionPath(pidInfo: PidInfo, phase: "worker" | "review",
   return null;
 }
 
-// --- JSONL line formatter ---
-
-export function formatLine(line: string): string | null {
-  let data: any;
-  try { data = JSON.parse(line); } catch { return null; }
-
+function formatClaudeLine(data: any): string | null {
   const type = data.type;
 
-  // Skip noise
   if (["permission-mode", "file-history-snapshot", "attachment", "queue-operation"].includes(type)) {
     return null;
   }
@@ -76,7 +68,6 @@ export function formatLine(line: string): string | null {
 
   if (type === "user" && data.message?.content) {
     const content = data.message.content;
-    // Tool results
     if (Array.isArray(content)) {
       const results: string[] = [];
       for (const block of content) {
@@ -94,7 +85,6 @@ export function formatLine(line: string): string | null {
       }
       return results.length > 0 ? results.join("\n") : null;
     }
-    // User prompt
     if (typeof content === "string") {
       return `${c.magenta("[prompt]")} ${truncate(content)}`;
     }
@@ -110,7 +100,41 @@ export function formatLine(line: string): string | null {
   return null;
 }
 
-// --- Log tailing ---
+function formatCodexLine(data: any): string | null {
+  const event = data.type ?? data.event ?? "event";
+
+  if (event.includes("plan") && (data.step || data.content)) {
+    return `${c.magenta("[plan]")} ${truncate(String(data.step ?? data.content), 180)}`;
+  }
+  if (event.includes("tool") || event.includes("exec") || event.includes("command")) {
+    const detail = data.command ?? data.name ?? data.output ?? data.content ?? "";
+    return `${c.yellow("[tool]")} ${c.bold(event)} ${c.dim(truncate(String(detail), 180))}`;
+  }
+  if (data.error) {
+    return `${c.red("[error]")} ${truncate(String(data.error), 180)}`;
+  }
+
+  const msg = data.msg ?? data.output ?? data.content ?? data.text;
+  if (msg) {
+    return `${c.cyan(`[${event}]`)} ${truncate(String(msg), 180)}`;
+  }
+
+  return `${c.dim("[event]")} ${truncate(JSON.stringify(data), 180)}`;
+}
+
+export function formatLine(line: string): string | null {
+  let data: any;
+  try { data = JSON.parse(line); } catch { return null; }
+
+  const maybeClaude = formatClaudeLine(data);
+  if (maybeClaude) return maybeClaude;
+
+  if (data.type || data.event || data.msg || data.output || data.error) {
+    return formatCodexLine(data);
+  }
+
+  return null;
+}
 
 export interface TailOptions {
   sessionPath: string;
@@ -127,12 +151,10 @@ export async function tailLog(opts: TailOptions): Promise<void> {
     process.exit(1);
   }
 
-  // Print existing content
   await printFile(sessionPath, raw);
 
   if (!follow) return;
 
-  // Follow mode: watch for changes
   let offset = statSync(sessionPath).size;
 
   const watcher = watch(sessionPath, () => {
@@ -156,13 +178,11 @@ export async function tailLog(opts: TailOptions): Promise<void> {
     });
   });
 
-  // Poll PID to detect when session ends
   if (pid) {
     const pollInterval = setInterval(() => {
       try {
         process.kill(pid, 0);
       } catch {
-        // Process gone
         clearInterval(pollInterval);
         watcher.close();
         console.log(c.dim("\n--- session ended ---"));
@@ -170,7 +190,6 @@ export async function tailLog(opts: TailOptions): Promise<void> {
     }, 3000);
   }
 
-  // Keep process alive until watcher closes or ctrl-c
   process.on("SIGINT", () => {
     watcher.close();
     process.exit(0);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
 import { spawn, execSync, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { join } from "node:path";
-import { readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { readFileSync, existsSync, mkdirSync, createWriteStream } from "node:fs";
 import {
   type DangeresqueConfig,
   CONFIG_DIR,
@@ -9,7 +9,7 @@ import {
   RESULT_FILE,
   projectHash,
 } from "./config.js";
-import { getLatestArchivedRun, writePidFile, updatePidFile, removePidFile } from "./worktree.js";
+import { getLatestArchivedRun, writePidFile, updatePidFile, removePidFile, readPidFile } from "./worktree.js";
 
 export interface RunOptions {
   projectRoot: string;
@@ -60,49 +60,7 @@ export function fetchIssue(
   };
 }
 
-function buildWorkerArgs(opts: RunOptions): { args: string[]; workerSessionId: string } {
-  const { config, projectRoot, name } = opts;
-  const worktreeName = name ?? `dangeresque-${Date.now()}`;
-  const configDir = join(projectRoot, CONFIG_DIR);
-  const headless = config.headless;
-
-  const args: string[] = [];
-
-  // Headless mode: -p (non-interactive, exits when done)
-  if (headless) {
-    args.push("-p");
-  }
-
-  // Worktree
-  args.push("--worktree", worktreeName);
-
-  // Model + effort
-  args.push("--model", config.model);
-  if (config.effort) {
-    args.push("--effort", config.effort);
-  }
-
-  // Permissions
-  args.push("--permission-mode", config.permissionMode);
-
-  // Worker-specific prompt (CLAUDE.md auto-discovered, this appends on top)
-  const workerPromptPath = join(configDir, config.workerPrompt);
-  args.push("--append-system-prompt-file", workerPromptPath);
-
-  // Tool permissions
-  if (config.allowedTools.length > 0) {
-    args.push("--allowed-tools", ...config.allowedTools);
-  }
-  if (config.disallowedTools.length > 0) {
-    args.push("--disallowed-tools", ...config.disallowedTools);
-  }
-
-  // Session name + ID for identification and log retrieval
-  args.push("--name", `dangeresque-worker-${worktreeName}`);
-  const workerSessionId = randomUUID();
-  args.push("--session-id", workerSessionId);
-
-  // Initial prompt: issue-driven or file-driven
+function buildTaskPrompt(opts: RunOptions): string {
   const mode = opts.mode ?? "INVESTIGATE";
 
   if (opts.issueData) {
@@ -114,11 +72,8 @@ function buildWorkerArgs(opts: RunOptions): { args: string[]; workerSessionId: s
       `# #${issueData.number}: ${issueData.title}\n\n` +
       `${issueData.body}`;
 
-    // Filter comments: skip minimized, then staged + last N human (skip [dangeresque] run results)
     const visibleComments = issueData.comments.filter(c => !c.isMinimized);
-    const stagedComments = visibleComments.filter(
-      (c) => c.body.startsWith("**[staged")
-    );
+    const stagedComments = visibleComments.filter((c) => c.body.startsWith("**[staged"));
     const humanComments = visibleComments.filter(
       (c) => !c.body.startsWith("**[staged") && !c.body.startsWith("**[dangeresque")
     );
@@ -132,7 +87,6 @@ function buildWorkerArgs(opts: RunOptions): { args: string[]; workerSessionId: s
       }
     }
 
-    // Include latest archived run result (if any prior run exists)
     const archivedResult = getLatestArchivedRun(opts.projectRoot, issueData.number);
     if (archivedResult) {
       prompt += `\n\n## Previous Run Result (from archive)\n\n${archivedResult}`;
@@ -142,33 +96,67 @@ function buildWorkerArgs(opts: RunOptions): { args: string[]; workerSessionId: s
       `\n\nFollow .dangeresque/AFK_WORKER_RULES.md (appended to your system prompt). ` +
       `Update RUN_RESULT.md before finishing.`;
 
-    args.push(prompt);
-  } else {
-    // Legacy: read from NEXT_TASK.md
-    const taskContent = readFileSync(join(projectRoot, TASK_FILE), "utf-8");
-    const modeMatch = taskContent.match(/^-\s*Mode:\s*(\w+)/m);
-    const fileMode = modeMatch?.[1] ?? mode;
-
-    args.push(
-      `You are an AFK worker executing a bounded task. ` +
-        `Mode: ${fileMode}. ` +
-        `Read NEXT_TASK.md for your full instructions. ` +
-        `Follow .dangeresque/AFK_WORKER_RULES.md (appended to your system prompt). ` +
-        `Update RUN_RESULT.md before finishing.`
-    );
+    return prompt;
   }
 
-  return { args, workerSessionId };
+  const taskContent = readFileSync(join(opts.projectRoot, TASK_FILE), "utf-8");
+  const modeMatch = taskContent.match(/^-\s*Mode:\s*(\w+)/m);
+  const fileMode = modeMatch?.[1] ?? mode;
+
+  return (
+    `You are an AFK worker executing a bounded task. ` +
+    `Mode: ${fileMode}. ` +
+    `Read NEXT_TASK.md for your full instructions. ` +
+    `Follow .dangeresque/AFK_WORKER_RULES.md (appended to your system prompt). ` +
+    `Update RUN_RESULT.md before finishing.`
+  );
 }
 
-function buildReviewArgs(opts: RunOptions, worktreeName: string): { args: string[]; reviewSessionId: string } {
+function buildClaudeWorkerArgs(opts: RunOptions, worktreeName: string): { args: string[]; workerSessionId: string } {
   const { config, projectRoot } = opts;
   const configDir = join(projectRoot, CONFIG_DIR);
   const headless = config.headless;
 
   const args: string[] = [];
 
-  // Headless mode: -p (non-interactive, exits when done)
+  if (headless) {
+    args.push("-p");
+  }
+
+  args.push("--worktree", worktreeName);
+  args.push("--model", config.model);
+  if (config.effort) {
+    args.push("--effort", config.effort);
+  }
+
+  args.push("--permission-mode", config.permissionMode);
+
+  const workerPromptPath = join(configDir, config.workerPrompt);
+  args.push("--append-system-prompt-file", workerPromptPath);
+
+  if (config.allowedTools.length > 0) {
+    args.push("--allowed-tools", ...config.allowedTools);
+  }
+  if (config.disallowedTools.length > 0) {
+    args.push("--disallowed-tools", ...config.disallowedTools);
+  }
+
+  args.push("--name", `dangeresque-worker-${worktreeName}`);
+  const workerSessionId = randomUUID();
+  args.push("--session-id", workerSessionId);
+
+  args.push(buildTaskPrompt(opts));
+
+  return { args, workerSessionId };
+}
+
+function buildClaudeReviewArgs(opts: RunOptions, worktreeName: string): { args: string[]; reviewSessionId: string } {
+  const { config, projectRoot } = opts;
+  const configDir = join(projectRoot, CONFIG_DIR);
+  const headless = config.headless;
+
+  const args: string[] = [];
+
   if (headless) {
     args.push("-p");
   }
@@ -179,9 +167,8 @@ function buildReviewArgs(opts: RunOptions, worktreeName: string): { args: string
   if (config.effort) {
     args.push("--effort", config.effort);
   }
-  args.push("--permission-mode", "acceptEdits"); // Reviewer needs to append to RUN_RESULT.md
+  args.push("--permission-mode", "acceptEdits");
 
-  // Reviewer needs read/write + git commit for RUN_RESULT.md in headless mode
   if (headless) {
     args.push(
       "--allowed-tools",
@@ -189,10 +176,7 @@ function buildReviewArgs(opts: RunOptions, worktreeName: string): { args: string
       "Bash(git status *)", "Bash(git diff *)", "Bash(git log *)",
       "Bash(git add *)", "Bash(git commit *)"
     );
-    args.push(
-      "--disallowed-tools",
-      ...config.disallowedTools
-    );
+    args.push("--disallowed-tools", ...config.disallowedTools);
   }
 
   const reviewPromptPath = join(configDir, config.reviewPrompt);
@@ -202,7 +186,6 @@ function buildReviewArgs(opts: RunOptions, worktreeName: string): { args: string
   const reviewSessionId = randomUUID();
   args.push("--session-id", reviewSessionId);
 
-  // Capture actual diff stat as ground truth for the reviewer
   let diffStat = "";
   try {
     diffStat = execSync("git diff main --stat", {
@@ -219,26 +202,82 @@ function buildReviewArgs(opts: RunOptions, worktreeName: string): { args: string
     const mode = opts.mode ?? "INVESTIGATE";
     args.push(
       `You are an adversarial reviewer of an AFK worker run.\n` +
-        `The task was GitHub Issue #${issueData.number}: ${issueData.title}\n` +
-        `Mode: ${mode}\n\n` +
-        `## Actual Diff (ground truth — captured automatically)\n\`\`\`\n${diffStat}\n\`\`\`\n\n` +
-        `Compare this against the worker's claimed file count in RUN_RESULT.md. ` +
-        `Any discrepancy is an automatic FAIL.\n\n` +
-        `Start by running git diff main to see full code changes. ` +
-        `Then read RUN_RESULT.md as a claims document to verify against the diff. ` +
-        `Follow review-prompt.md. Append findings to RUN_RESULT.md.`
+      `The task was GitHub Issue #${issueData.number}: ${issueData.title}\n` +
+      `Mode: ${mode}\n\n` +
+      `## Actual Diff (ground truth — captured automatically)\n\`\`\`\n${diffStat}\n\`\`\`\n\n` +
+      `Compare this against the worker's claimed file count in RUN_RESULT.md. ` +
+      `Any discrepancy is an automatic FAIL.\n\n` +
+      `Start by running git diff main to see full code changes. ` +
+      `Then read RUN_RESULT.md as a claims document to verify against the diff. ` +
+      `Follow review-prompt.md. Append findings to RUN_RESULT.md.`
     );
   } else {
     args.push(
       `You are an adversarial reviewer of an AFK worker run.\n\n` +
-        `## Actual Diff (ground truth — captured automatically)\n\`\`\`\n${diffStat}\n\`\`\`\n\n` +
-        `Start by running git diff main to see full code changes. ` +
-        `Then read RUN_RESULT.md as a claims document to verify against the diff. ` +
-        `Follow review-prompt.md. Append findings to RUN_RESULT.md.`
+      `## Actual Diff (ground truth — captured automatically)\n\`\`\`\n${diffStat}\n\`\`\`\n\n` +
+      `Start by running git diff main to see full code changes. ` +
+      `Then read RUN_RESULT.md as a claims document to verify against the diff. ` +
+      `Follow review-prompt.md. Append findings to RUN_RESULT.md.`
     );
   }
 
   return { args, reviewSessionId };
+}
+
+function buildCodexWorkerArgs(opts: RunOptions, worktreeName: string): string[] {
+  const worktreePath = join(opts.projectRoot, ".claude", "worktrees", worktreeName);
+  const prompt = buildTaskPrompt(opts) + `\n\nEffort preference: ${opts.config.effort} (map this to response depth and planning thoroughness).`;
+
+  return [
+    "exec",
+    "--json",
+    "--full-auto",
+    "--model", opts.config.model,
+    "--cd", worktreePath,
+    prompt,
+  ];
+}
+
+function buildCodexReviewArgs(opts: RunOptions, worktreeName: string): string[] {
+  let diffStat = "";
+  try {
+    diffStat = execSync("git diff main --stat", {
+      cwd: join(opts.projectRoot, ".claude", "worktrees", worktreeName),
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    diffStat = "(could not capture diff stat)";
+  }
+
+  const prompt = opts.issueData
+    ? (
+      `You are an adversarial reviewer of an AFK worker run.\n` +
+      `The task was GitHub Issue #${opts.issueData.number}: ${opts.issueData.title}\n` +
+      `Mode: ${opts.mode ?? "INVESTIGATE"}\n\n` +
+      `## Actual Diff (ground truth — captured automatically)\n\`\`\`\n${diffStat}\n\`\`\`\n\n` +
+      `Compare this against the worker's claimed file count in RUN_RESULT.md. ` +
+      `Any discrepancy is an automatic FAIL.\n\n` +
+      `Start by running git diff main to see full code changes. ` +
+      `Then read RUN_RESULT.md as a claims document to verify against the diff. ` +
+      `Follow review-prompt.md. Append findings to RUN_RESULT.md.`
+    )
+    : (
+      `You are an adversarial reviewer of an AFK worker run.\n\n` +
+      `## Actual Diff (ground truth — captured automatically)\n\`\`\`\n${diffStat}\n\`\`\`\n\n` +
+      `Start by running git diff main to see full code changes. ` +
+      `Then read RUN_RESULT.md as a claims document to verify against the diff. ` +
+      `Follow review-prompt.md. Append findings to RUN_RESULT.md.`
+    );
+
+  return [
+    "exec",
+    "--json",
+    "--full-auto",
+    "--model", opts.config.model,
+    "--cd", join(opts.projectRoot, ".claude", "worktrees", worktreeName),
+    prompt,
+  ];
 }
 
 function ensureDangeresquePrefix(name: string): string {
@@ -261,14 +300,99 @@ function checkRemoteBehind(projectRoot: string): void {
   }
 }
 
+function ensureWorktreeExists(projectRoot: string, worktreeName: string, branch: string): string {
+  const worktreePath = join(projectRoot, ".claude", "worktrees", worktreeName);
+  if (existsSync(worktreePath)) return worktreePath;
+
+  mkdirSync(dirname(worktreePath), { recursive: true });
+
+  let baseRef = "HEAD";
+  try {
+    baseRef = execSync("git symbolic-ref --quiet --short refs/remotes/origin/HEAD", {
+      cwd: projectRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    baseRef = "HEAD";
+  }
+
+  execSync(`git worktree add -b ${branch} "${worktreePath}" ${baseRef}`, {
+    cwd: projectRoot,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  return worktreePath;
+}
+
+function createCodexLogPath(worktreePath: string, phase: "worker" | "review"): string {
+  const logDir = join(worktreePath, ".dangeresque");
+  mkdirSync(logDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return join(logDir, `${phase}-codex-${timestamp}.jsonl`);
+}
+
 export function runWorker(opts: RunOptions): Promise<RunResult> {
   checkRemoteBehind(opts.projectRoot);
 
   const worktreeName = ensureDangeresquePrefix(opts.name ?? `${Date.now()}`);
-  const { args, workerSessionId } = buildWorkerArgs({ ...opts, name: worktreeName });
   const branch = `worktree-${worktreeName}`;
   const worktreePath = join(opts.projectRoot, ".claude", "worktrees", worktreeName);
   const hash = projectHash(worktreePath);
+
+  if (opts.config.engine === "codex") {
+    ensureWorktreeExists(opts.projectRoot, worktreeName, branch);
+    const args = buildCodexWorkerArgs(opts, worktreeName);
+    const logPath = createCodexLogPath(worktreePath, "worker");
+
+    return new Promise((resolve, reject) => {
+      console.log(`\n🏗️  Starting worker in worktree: ${worktreeName}`);
+      console.log(`📋 Branch: ${branch}`);
+      console.log(`⚙️  Engine: codex`);
+      console.log(`🔧 Model: ${opts.config.model}`);
+      console.log(`📂 Config: ${join(opts.projectRoot, CONFIG_DIR)}/`);
+      console.log(`\n--- Worker session starting ---\n`);
+
+      const child = spawn("codex", args, {
+        cwd: worktreePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env },
+      });
+
+      const logStream = createWriteStream(logPath, { flags: "a" });
+      child.stdout?.on("data", (chunk: Buffer) => {
+        process.stdout.write(chunk);
+        logStream.write(chunk);
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        process.stderr.write(chunk);
+        logStream.write(chunk);
+      });
+
+      if (child.pid) {
+        writePidFile(worktreePath, child.pid, {
+          engine: "codex",
+          projectHash: hash,
+          workerLogPath: logPath,
+        });
+      }
+
+      child.on("error", (err: Error) => {
+        logStream.end();
+        removePidFile(worktreePath);
+        reject(new Error(`Failed to start codex: ${err.message}`));
+      });
+
+      child.on("close", (code: number | null) => {
+        logStream.end();
+        removePidFile(worktreePath);
+        resolve({ worktreeName, branch, exitCode: code ?? 0 });
+      });
+    });
+  }
+
+  const { args, workerSessionId } = buildClaudeWorkerArgs(opts, worktreeName);
 
   return new Promise((resolve, reject) => {
     console.log(`\n🏗️  Starting worker in worktree: ${worktreeName}`);
@@ -283,11 +407,9 @@ export function runWorker(opts: RunOptions): Promise<RunResult> {
       env: { ...process.env },
     });
 
-    // Write PID file once spawned (worktree may not exist yet — write after short delay)
     if (child.pid) {
-      // Worktree is created by claude CLI; wait briefly for it to exist
       setTimeout(() => {
-        try { writePidFile(worktreePath, child.pid!, { workerSessionId, projectHash: hash }); } catch { /* worktree not ready yet — ok */ }
+        try { writePidFile(worktreePath, child.pid!, { workerSessionId, projectHash: hash, engine: "claude" }); } catch { /* worktree not ready yet — ok */ }
       }, 3000);
     }
 
@@ -313,9 +435,58 @@ export function runReview(
   worktreeName: string,
   workerSessionId?: string
 ): Promise<RunResult> {
-  const { args, reviewSessionId } = buildReviewArgs(opts, worktreeName);
   const branch = `worktree-${worktreeName}`;
   const worktreePath = join(opts.projectRoot, ".claude", "worktrees", worktreeName);
+  const hash = projectHash(worktreePath);
+
+  if (opts.config.engine === "codex") {
+    const args = buildCodexReviewArgs(opts, worktreeName);
+    const logPath = createCodexLogPath(worktreePath, "review");
+
+    return new Promise((resolve, reject) => {
+      console.log(`\n--- Review session starting ---\n`);
+
+      const child = spawn("codex", args, {
+        cwd: worktreePath,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env },
+      });
+
+      const logStream = createWriteStream(logPath, { flags: "a" });
+      child.stdout?.on("data", (chunk: Buffer) => {
+        process.stdout.write(chunk);
+        logStream.write(chunk);
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        process.stderr.write(chunk);
+        logStream.write(chunk);
+      });
+
+      if (child.pid) {
+        const existing = readPidFile(worktreePath);
+        writePidFile(worktreePath, child.pid, {
+          engine: "codex",
+          projectHash: hash,
+          workerLogPath: existing?.workerLogPath,
+          reviewLogPath: logPath,
+        });
+      }
+
+      child.on("error", (err: Error) => {
+        logStream.end();
+        removePidFile(worktreePath);
+        reject(new Error(`Failed to start codex review: ${err.message}`));
+      });
+
+      child.on("close", (code: number | null) => {
+        logStream.end();
+        removePidFile(worktreePath);
+        resolve({ worktreeName, branch, exitCode: code ?? 0 });
+      });
+    });
+  }
+
+  const { args, reviewSessionId } = buildClaudeReviewArgs(opts, worktreeName);
 
   return new Promise((resolve, reject) => {
     console.log(`\n--- Review session starting ---\n`);
@@ -326,10 +497,9 @@ export function runReview(
       env: { ...process.env },
     });
 
-    // Write PID file for review process (worker's PID file was removed on close)
     if (child.pid) {
-      const hash = projectHash(worktreePath);
-      writePidFile(worktreePath, child.pid, { reviewSessionId, workerSessionId, projectHash: hash });
+      writePidFile(worktreePath, child.pid, { reviewSessionId, workerSessionId, projectHash: hash, engine: "claude" });
+      updatePidFile(worktreePath, { reviewSessionId, workerSessionId, projectHash: hash, engine: "claude" });
     }
 
     child.on("error", (err: Error) => {
@@ -339,11 +509,7 @@ export function runReview(
 
     child.on("close", (code: number | null) => {
       removePidFile(worktreePath);
-      resolve({
-        worktreeName,
-        branch,
-        exitCode: code ?? 0,
-      });
+      resolve({ worktreeName, branch, exitCode: code ?? 0 });
     });
   });
 }

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -9,6 +9,9 @@ export interface PidInfo {
   workerSessionId?: string;
   reviewSessionId?: string;
   projectHash?: string;
+  engine?: "claude" | "codex";
+  workerLogPath?: string;
+  reviewLogPath?: string;
 }
 
 export interface WorktreeInfo {
@@ -41,7 +44,7 @@ export function listWorktrees(projectRoot: string): WorktreeInfo[] {
     const branch = branchLine.replace("branch refs/heads/", "");
     const head = headLine?.replace("HEAD ", "") ?? "";
 
-    // Include all Claude Code worktrees (they live under .claude/worktrees/)
+    // Include all dangeresque worktrees (they live under .claude/worktrees/)
     if (path.includes(".claude/worktrees/")) {
       let commitEpoch = 0;
       try {


### PR DESCRIPTION
### Motivation

- Introduce support for running Dangeresque with either Anthropic Claude or OpenAI Codex as interchangeable execution engines to expand automation options and accommodate environment constraints.
- Make help text, configuration, and runtime behaviour adapt to the selected engine so engine-specific flags and semantics are clear to users.

### Description

- Add `engine` to `config.json` and `DangeresqueConfig`, defaulting to `"claude"`, and validate supported engines in `config.ts`.
- Implement dynamic CLI help and engine selection via `DANGERESQUE_ENGINE` or a hidden `--engine` flag in `src/cli.ts`, and warn when Claude-only flags (e.g. `--effort`) are used with Codex.
- Extend `runner.ts` to support Codex: build Codex worker/review argument flows, create worktrees when needed, persist per-run Codex JSONL logs, and write PID metadata including engine and log paths; keep existing Claude flows but refactor argument builders and prompt handling into reusable helpers.
- Update `logs.ts` to detect and pretty-print both Claude JSONL and Codex-style events with separate formatters and to respect stored log paths from PID files when present.
- Enhance `worktree.ts` PID metadata to include `engine`, `workerLogPath`, and `reviewLogPath` and update PID read/write usage across runner flows.
- Update docs and packaging: `README.md` describes engine switching and Codex mapping, and `package.json` description/keywords updated for Codex.

### Testing

- Ran the TypeScript build with `yarn build` (runs `tsc`) to ensure the project compiles successfully and the new types/exports integrate; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51f95e08c83219fa1a234a5ddc0a0)