### PR TITLE
fix: merge mirrors run artifacts by issue-* dir, not branch-parsed number

### DIFF
--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -307,6 +307,38 @@ export function mirrorIssueRuns(
 }
 
 /**
+ * Copy EVERY `issue-*` run directory found under srcRoot's runs dir to destRoot.
+ * Used on merge to carry a worktree's gitignored run artifacts back to the
+ * project root. Unlike mirrorIssueRuns this takes no issue number: the runs are
+ * keyed by the real issue number at write time, independent of the branch name,
+ * so the dirs on disk are the source of truth. Parsing the number out of the
+ * branch name instead silently lost artifacts whenever the name carried a slug
+ * suffix (e.g. `-dicecursor`) — see the merge call site. Returns the issue
+ * directory names copied (e.g. ["issue-537"]); empty when there's nothing to
+ * mirror.
+ */
+export function mirrorAllIssueRuns(
+  srcRoot: string,
+  destRoot: string,
+): string[] {
+  const srcRunsDir = getRunsDir(srcRoot);
+  if (!existsSync(srcRunsDir)) return [];
+  const issueDirs = readdirSync(srcRunsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && e.name.startsWith("issue-"))
+    .map((e) => e.name);
+  if (issueDirs.length === 0) return [];
+  const destRunsDir = getRunsDir(destRoot);
+  mkdirSync(destRunsDir, { recursive: true });
+  for (const name of issueDirs) {
+    cpSync(join(srcRunsDir, name), join(destRunsDir, name), {
+      recursive: true,
+      force: true,
+    });
+  }
+  return issueDirs;
+}
+
+/**
  * List run result files for an issue, sorted chronologically (oldest first).
  */
 export function listArchivedRuns(
@@ -438,9 +470,16 @@ export function cleanArchivedRuns(
 /**
  * Extract issue number from branch name.
  * worktree-dangeresque-investigate-63 → 63
+ * Tolerates a descriptive slug after the number (used to disambiguate
+ * multiple runs on one issue): worktree-dangeresque-investigate-63-dicecursor → 63.
+ * The number is the segment immediately after the mode word, so it's matched
+ * there rather than anchored to the end of the string.
  */
 export function extractIssueNumber(branch: string): number | undefined {
-  const match = branch.match(/-(\d+)$/);
+  const stripped = branch
+    .replace(/^worktree-/, "")
+    .replace(/^dangeresque-/, "");
+  const match = stripped.match(/^[a-z]+-(\d+)(?:-.*)?$/);
   return match ? parseInt(match[1], 10) : undefined;
 }
 
@@ -563,28 +602,54 @@ export function mergeWorktree(
     : `Merge succeeded — main is now at ${headAfter.slice(0, 8)} (was ${headBefore.slice(0, 8)})`;
 
   // Phase 2: worktree cleanup (worktreePath already resolved at top of function).
-  // Mirror gitignored run artifacts out of the worktree before removing it,
-  // so per-run history persists at the project root after merge.
+  // Mirror gitignored run artifacts out of the worktree before removing it, so
+  // per-run history persists at the project root after merge. Driven by the
+  // issue-* dirs actually present in the worktree (the source of truth) rather
+  // than a number parsed from the branch name — a descriptive branch slug like
+  // `-dicecursor` used to make extractIssueNumber return undefined, which
+  // silently skipped this whole step while still reporting success. Verified
+  // after copy and failed loud if anything didn't land — the success line must
+  // never claim a mirror that didn't happen.
+  let mirrorNote = "";
   if (existsSync(worktreePath)) {
-    const issueNumber = extractIssueNumber(branch);
-    if (issueNumber !== undefined) {
-      try {
-        mirrorIssueRuns(worktreePath, projectRoot, issueNumber);
-      } catch (err) {
-        return {
-          success: false,
-          phase: "cleanup",
-          headAdvanced: !noopMerge,
-          headBefore,
-          headAfter,
-          message:
-            `${mergeOutcome}. ` +
-            `Mirroring run artifacts to project root failed: ${err instanceof Error ? err.message : String(err)}. ` +
-            `Worktree NOT removed at ${worktreePath} — copy ${worktreePath}/.dangeresque/runs/issue-${issueNumber}/ ` +
-            `to ${projectRoot}/.dangeresque/runs/issue-${issueNumber}/, then 'dangeresque discard ${branch}' to clean up.`,
-        };
-      }
+    let mirrored: string[];
+    try {
+      mirrored = mirrorAllIssueRuns(worktreePath, projectRoot);
+    } catch (err) {
+      return {
+        success: false,
+        phase: "cleanup",
+        headAdvanced: !noopMerge,
+        headBefore,
+        headAfter,
+        message:
+          `${mergeOutcome}. ` +
+          `Mirroring run artifacts to project root failed: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Worktree NOT removed at ${worktreePath} — copy ${worktreePath}/.dangeresque/runs/ ` +
+          `to ${projectRoot}/.dangeresque/runs/, then 'dangeresque discard ${branch}' to clean up.`,
+      };
     }
+    const missing = mirrored.filter(
+      (dir) => !existsSync(join(getRunsDir(projectRoot), dir)),
+    );
+    if (missing.length > 0) {
+      return {
+        success: false,
+        phase: "cleanup",
+        headAdvanced: !noopMerge,
+        headBefore,
+        headAfter,
+        message:
+          `${mergeOutcome}. ` +
+          `Run artifacts failed to land at project root (${missing.join(", ")}). ` +
+          `Worktree NOT removed at ${worktreePath} — copy ${worktreePath}/.dangeresque/runs/ ` +
+          `to ${projectRoot}/.dangeresque/runs/, then 'dangeresque discard ${branch}' to clean up.`,
+      };
+    }
+    mirrorNote =
+      mirrored.length > 0
+        ? `Mirrored run artifacts (${mirrored.join(", ")}) to project root and removed worktree.`
+        : `No run artifacts to mirror; removed worktree.`;
     try {
       execSync(`git worktree remove "${worktreePath}"`, {
         cwd: projectRoot,
@@ -640,8 +705,8 @@ export function mergeWorktree(
     headBefore,
     headAfter,
     message: noopMerge
-      ? `Merged ${branch}: no code changes (HEAD unchanged at ${headBefore.slice(0, 7)}). Mirrored run artifacts to project root and removed worktree.`
-      : `Merged ${branch} into main. Main: ${headBefore.slice(0, 7)} → ${headAfter.slice(0, 7)}.`,
+      ? `Merged ${branch}: no code changes (HEAD unchanged at ${headBefore.slice(0, 7)}). ${mirrorNote}`.trim()
+      : `Merged ${branch} into main. Main: ${headBefore.slice(0, 7)} → ${headAfter.slice(0, 7)}. ${mirrorNote}`.trim(),
   };
 }
 

--- a/test/unit/worktree.test.ts
+++ b/test/unit/worktree.test.ts
@@ -16,6 +16,7 @@ import {
   filterWorktrees,
   isPidAlive,
   mirrorIssueRuns,
+  mirrorAllIssueRuns,
   stopWorktree,
   runPreflightChecks,
   type WorktreeInfo,
@@ -27,6 +28,23 @@ test("extractIssueNumber: dangeresque-prefixed branch → number", () => {
 
 test("extractIssueNumber: no trailing number → undefined", () => {
   assert.equal(extractIssueNumber("worktree-foo-bar"), undefined);
+});
+
+test("extractIssueNumber: descriptive slug after number → number (bc#546)", () => {
+  // The merge artifact-mirror bug: a slug suffix used to return undefined,
+  // silently skipping the mirror while reporting success.
+  assert.equal(
+    extractIssueNumber("worktree-dangeresque-investigate-537-dicecursor"),
+    537,
+  );
+  assert.equal(
+    extractIssueNumber("worktree-dangeresque-implement-534-slice1"),
+    534,
+  );
+  assert.equal(
+    extractIssueNumber("worktree-dangeresque-implement-537-p1-fix"),
+    537,
+  );
 });
 
 test("extractMode: dangeresque-prefixed branch", () => {
@@ -468,7 +486,7 @@ test("mergeWorktree: copies gitignored runs/issue-N/ from worktree to project ro
   }
 });
 
-test("mergeWorktree: branch without issue number → no copy attempted, merge still succeeds", () => {
+test("mergeWorktree: branch with no run artifacts → merge succeeds, no false mirror claim", () => {
   const dir = makeRepo();
   try {
     addWorktree(dir, "no-issue", "worktree-no-issue");
@@ -477,10 +495,103 @@ test("mergeWorktree: branch without issue number → no copy attempted, merge st
     assert.equal(
       existsSync(join(dir, ".dangeresque", "runs")),
       false,
-      "no runs/ dir should be created when branch has no issue number",
+      "no runs/ dir should be created when there are no artifacts",
     );
+    // The success line must not claim a mirror that didn't happen.
+    assert.doesNotMatch(result.message, /Mirrored run artifacts/);
+    assert.match(result.message, /No run artifacts to mirror/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("mergeWorktree: slug-suffixed branch with gitignored artifact → still mirrors (bc#546 regression)", () => {
+  // The exact shape that broke: branch ends in `-dicecursor`, not `-537`.
+  // Old extractIssueNumber returned undefined → mirror skipped → artifacts lost
+  // while merge reported success.
+  const dir = makeRepo();
+  try {
+    writeFileSync(join(dir, ".gitignore"), ".dangeresque/runs/\n");
+    execSync("git add .gitignore", env(dir));
+    execSync('git commit -m "gitignore runs"', env(dir));
+
+    const worktreePath = addWorktree(
+      dir,
+      "dangeresque-investigate-537-dicecursor",
+      "worktree-dangeresque-investigate-537-dicecursor",
+      { advance: false },
+    );
+    const wtArtifactDir = join(worktreePath, ".dangeresque", "runs", "issue-537");
+    mkdirSync(wtArtifactDir, { recursive: true });
+    writeFileSync(
+      join(wtArtifactDir, "2026-06-19T23-04-14-IMPLEMENT.md"),
+      "<!-- SUMMARY -->\nMode: IMPLEMENT | Status: implemented\n<!-- /SUMMARY -->\n",
+    );
+    writeFileSync(
+      join(wtArtifactDir, "2026-06-19T23-04-14-IMPLEMENT.json"),
+      '{"schema_version":"3"}\n',
+    );
+
+    const result = mergeWorktree(
+      dir,
+      "worktree-dangeresque-investigate-537-dicecursor",
+    );
+    assert.equal(result.success, true);
+    assert.equal(existsSync(worktreePath), false);
+
+    // BOTH the .md and the .json eval sidecar must land at the project root.
+    const projectIssueDir = join(dir, ".dangeresque", "runs", "issue-537");
+    assert.ok(
+      existsSync(join(projectIssueDir, "2026-06-19T23-04-14-IMPLEMENT.md")),
+      ".md mirrored despite slug-suffixed branch",
+    );
+    assert.ok(
+      existsSync(join(projectIssueDir, "2026-06-19T23-04-14-IMPLEMENT.json")),
+      ".json eval sidecar mirrored despite slug-suffixed branch",
+    );
+    // And the success line names what it actually mirrored.
+    assert.match(result.message, /Mirrored run artifacts \(issue-537\)/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- mirrorAllIssueRuns: name-independent copy of every issue-* dir ---
+
+test("mirrorAllIssueRuns: src runs dir missing → [] , no error", () => {
+  const src = mkdtempSync(join(tmpdir(), "dangeresque-mirror-all-src-"));
+  const dest = mkdtempSync(join(tmpdir(), "dangeresque-mirror-all-dest-"));
+  try {
+    assert.deepEqual(mirrorAllIssueRuns(src, dest), []);
+    assert.equal(existsSync(join(dest, ".dangeresque", "runs")), false);
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
+test("mirrorAllIssueRuns: copies every issue-* dir, returns their names", () => {
+  const src = mkdtempSync(join(tmpdir(), "dangeresque-mirror-all-src-"));
+  const dest = mkdtempSync(join(tmpdir(), "dangeresque-mirror-all-dest-"));
+  try {
+    const runs = join(src, ".dangeresque", "runs");
+    mkdirSync(join(runs, "issue-7"), { recursive: true });
+    writeFileSync(join(runs, "issue-7", "a.md"), "7\n");
+    mkdirSync(join(runs, "issue-8"), { recursive: true });
+    writeFileSync(join(runs, "issue-8", "b.json"), "{}\n");
+    // A stray non-issue dir must be ignored.
+    mkdirSync(join(runs, "scratch"), { recursive: true });
+
+    const copied = mirrorAllIssueRuns(src, dest).sort();
+    assert.deepEqual(copied, ["issue-7", "issue-8"]);
+
+    const destRuns = join(dest, ".dangeresque", "runs");
+    assert.ok(existsSync(join(destRuns, "issue-7", "a.md")));
+    assert.ok(existsSync(join(destRuns, "issue-8", "b.json")));
+    assert.equal(existsSync(join(destRuns, "scratch")), false);
+  } finally {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Bug
`dangeresque merge <branch>` silently lost run reports (`.md` + `.json` eval sidecar) while printing *"Mirrored run artifacts to project root"* — whenever a worktree `--name` carried a slug after the issue number (e.g. `dangeresque-investigate-537-dicecursor`, `-545-harness`, `-534-slice1`).

## Root cause
`extractIssueNumber` anchored the number to end-of-string (`/-(\d+)$/`), so a trailing slug → `undefined`. The merge mirror block was gated on `if (issueNumber !== undefined)`, so the copy was skipped — but the worktree was still removed and the success line still claimed a mirror. Latent since forever; exposed this session by the new habit of descriptive branch slugs. (Inbound dispatch-time mirror was unaffected — it uses the real issue number, not the branch name.)

Same brittle parse also silently broke `dangeresque results <slug-branch>` (no runs shown) and the preflight duplicate-worktree gate (failed to fire).

## Fix
- **`extractIssueNumber`** — match the number right after the mode word, tolerate a trailing slug. Fixes `results` + preflight gate too.
- **`merge`** — new `mirrorAllIssueRuns` copies *every* `issue-*` dir present in the worktree (source of truth, name-independent → works for any name), **verifies** they landed, and **fails loud** with recovery steps instead of false success. Success message now states what it mirrored, or `No run artifacts to mirror`.
- **tests** — slug-branch merge-then-assert (`.md`+`.json`), `extractIssueNumber` slug cases, `mirrorAllIssueRuns`, and a no-false-mirror-claim assertion. **375/375 green.**

## Note
`dist/` is gitignored (rebuilt via `postinstall`); since `dangeresque` symlinks to this repo's `dist/cli.js`, the fix is already live locally after build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)